### PR TITLE
feat: wildcard request params

### DIFF
--- a/lib/app/utils/db-utils.js
+++ b/lib/app/utils/db-utils.js
@@ -19,11 +19,11 @@ module.exports = class DBUtils {
 
   /**
    * Compare string ignoring cases
-   * @param {string} stringOne
-   * @param {string} stringTwo
+   * @param {string} reqString
+   * @param {string} receivedString
    * @return {boolean} format id.
    */
-  static isEq(stringOne, stringTwo) {
-    return stringOne.toUpperCase() === stringTwo.toUpperCase();
+  static isEq(reqString, receivedString) {
+    return reqString === '*' || reqString.toUpperCase() === receivedString.toUpperCase();
   };
 };

--- a/test/unit/utils/db-utils.test.js
+++ b/test/unit/utils/db-utils.test.js
@@ -46,6 +46,15 @@ describe('db utils', () => {
 
       expect(result).to.be.false;
     });
+
+    it(`should return true when the req string is the wildcard '*'`, () => {
+      const stringOne = `*`;
+      const stringTwo = `anything`;
+
+      const result = DBUtils.isEq(stringOne, stringTwo);
+
+      expect(result).to.be.true;
+    });
   });
 });
 


### PR DESCRIPTION
closes #62 

This seemed to be the easiest way to implement this feature - having the request match without listing the params in the `_req` object would be a bit more complex, so went with the `"_param": "*"` syntax.