### PR TITLE
feat: no delay flag

### DIFF
--- a/lib/app/shared/bases/service-base.js
+++ b/lib/app/shared/bases/service-base.js
@@ -5,6 +5,8 @@ const ResUtils = require('./../../utils/res-utils');
 const environment = require('./../../../environment/index');
 const { id } = require('./../../components/status/status.router');
 
+const args = require('minimist')(process.argv.slice(2));
+
 module.exports = class ServiceBase {
   /**
    * @description Deal with the response.
@@ -39,6 +41,7 @@ module.exports = class ServiceBase {
  * @return {number} miliseconds
  */
 const setDelay = (res) => {
-  return res && res._delay ? res._delay : 0;
+  const disabled = args['no-delays'] || false;
+  return !disabled && res && res._delay ? res._delay : 0;
 };
 

--- a/lib/app/shared/bases/service-base.js
+++ b/lib/app/shared/bases/service-base.js
@@ -41,7 +41,7 @@ module.exports = class ServiceBase {
  * @return {number} miliseconds
  */
 const setDelay = (res) => {
-  const disabled = args['no-delays'] || false;
+  const disabled = args['no_delays'] || false;
   return !disabled && res && res._delay ? res._delay : 0;
 };
 


### PR DESCRIPTION
closes #73

The server can now be run with `--no_delays`, which will ignore any delays defined in the resource files.

I didn't update the documentation because I wasn't sure where would be best to mention this, any help would be appreciated.